### PR TITLE
refactor(Button): replace transform-based animation with background-size

### DIFF
--- a/src/components/atoms/Buttons/index.module.scss
+++ b/src/components/atoms/Buttons/index.module.scss
@@ -18,7 +18,6 @@
     flex-flow: row;
     align-items: center;
     justify-content: center;
-    overflow: hidden;
     line-height: inherit;
     appearance: none;
     border-style: solid;
@@ -72,41 +71,31 @@
     &--fill {
       color: var(--btn-primary-text);
       background-color: var(--btn-primary-surface);
+      background-image: radial-gradient(
+        ellipse at bottom left,
+        var(--doc-bg) 0%,
+        var(--doc-bg) 50%,
+        transparent 50%,
+        transparent 100%
+      );
+      background-repeat: no-repeat;
+      background-position: bottom left;
+      background-size: 0 0;
       border-color: var(--btn-primary-border-color);
 
-      &::before {
-        position: absolute;
-        bottom: 0;
-        left: 0;
-        z-index: -1;
-        width: 300%;
-        height: 300%;
-        content: "";
-        background: radial-gradient(
-          ellipse at bottom left,
-          var(--doc-bg) 0%,
-          var(--doc-bg) 50%,
-          transparent 50%,
-          transparent 100%
-        );
-        transform: scale(0);
-        transform-origin: bottom left;
-
-        @media (prefers-reduced-motion: no-preference) {
-          transition: transform var(--transition-duration) ease-out;
-        }
+      @media (prefers-reduced-motion: no-preference) {
+        transition:
+          color var(--transition-duration) ease,
+          background-size var(--transition-duration) ease-out;
       }
 
       &:focus,
       &:hover {
         color: var(--btn-primary-surface);
+        background-size: 300% 300%;
 
         @media (prefers-reduced-motion: reduce) {
           background-color: var(--doc-bg);
-        }
-
-        &::before {
-          transform: scale(1);
         }
       }
     }
@@ -114,41 +103,31 @@
     &--outline {
       color: var(--btn-primary-surface);
       background-color: var(--doc-bg);
+      background-image: radial-gradient(
+        ellipse at bottom left,
+        var(--btn-primary-surface) 0%,
+        var(--btn-primary-surface) 50%,
+        transparent 50%,
+        transparent 100%
+      );
+      background-repeat: no-repeat;
+      background-position: bottom left;
+      background-size: 0 0;
       border-color: var(--btn-primary-surface);
 
-      &::before {
-        position: absolute;
-        bottom: 0;
-        left: 0;
-        z-index: -1;
-        width: 300%;
-        height: 300%;
-        content: "";
-        background: radial-gradient(
-          ellipse at bottom left,
-          var(--btn-primary-surface) 0%,
-          var(--btn-primary-surface) 50%,
-          transparent 50%,
-          transparent 100%
-        );
-        transform: scale(0);
-        transform-origin: bottom left;
-
-        @media (prefers-reduced-motion: no-preference) {
-          transition: transform var(--transition-duration) ease-out;
-        }
+      @media (prefers-reduced-motion: no-preference) {
+        transition:
+          color var(--transition-duration) ease,
+          background-size var(--transition-duration) ease-out;
       }
 
       &:focus,
       &:hover {
         color: var(--btn-primary-text);
+        background-size: 300% 300%;
 
         @media (prefers-reduced-motion: reduce) {
           background-color: var(--btn-primary-surface);
-        }
-
-        &::before {
-          transform: scale(1);
         }
       }
 
@@ -183,41 +162,31 @@
     &--fill {
       color: var(--btn-primary-text);
       background-color: var(--btn-primary-surface);
+      background-image: radial-gradient(
+        ellipse at bottom left,
+        var(--doc-bg) 0%,
+        var(--doc-bg) 50%,
+        transparent 50%,
+        transparent 100%
+      );
+      background-repeat: no-repeat;
+      background-position: bottom left;
+      background-size: 0 0;
       border-color: var(--btn-primary-border-color);
 
-      &::before {
-        position: absolute;
-        bottom: 0;
-        left: 0;
-        z-index: -1;
-        width: 300%;
-        height: 300%;
-        content: "";
-        background: radial-gradient(
-          ellipse at bottom left,
-          var(--doc-bg) 0%,
-          var(--doc-bg) 50%,
-          transparent 50%,
-          transparent 100%
-        );
-        transform: scale(0);
-        transform-origin: bottom left;
-
-        @media (prefers-reduced-motion: no-preference) {
-          transition: transform var(--transition-duration) ease-out;
-        }
+      @media (prefers-reduced-motion: no-preference) {
+        transition:
+          color var(--transition-duration) ease,
+          background-size var(--transition-duration) ease-out;
       }
 
       &:focus,
       &:hover {
         color: var(--btn-primary-surface);
+        background-size: 300% 300%;
 
         @media (prefers-reduced-motion: reduce) {
           background-color: var(--doc-bg);
-        }
-
-        &::before {
-          transform: scale(1);
         }
       }
     }
@@ -225,41 +194,31 @@
     &--outline {
       color: var(--btn-primary-surface);
       background-color: var(--doc-bg);
+      background-image: radial-gradient(
+        ellipse at bottom left,
+        var(--btn-primary-surface) 0%,
+        var(--btn-primary-surface) 50%,
+        transparent 50%,
+        transparent 100%
+      );
+      background-repeat: no-repeat;
+      background-position: bottom left;
+      background-size: 0 0;
       border-color: var(--btn-primary-surface);
 
-      &::before {
-        position: absolute;
-        bottom: 0;
-        left: 0;
-        z-index: -1;
-        width: 300%;
-        height: 300%;
-        content: "";
-        background: radial-gradient(
-          ellipse at bottom left,
-          var(--btn-primary-surface) 0%,
-          var(--btn-primary-surface) 50%,
-          transparent 50%,
-          transparent 100%
-        );
-        transform: scale(0);
-        transform-origin: bottom left;
-
-        @media (prefers-reduced-motion: no-preference) {
-          transition: transform var(--transition-duration) ease-out;
-        }
+      @media (prefers-reduced-motion: no-preference) {
+        transition:
+          color var(--transition-duration) ease,
+          background-size var(--transition-duration) ease-out;
       }
 
       &:focus,
       &:hover {
         color: var(--btn-primary-text);
+        background-size: 300% 300%;
 
         @media (prefers-reduced-motion: reduce) {
           background-color: var(--btn-primary-surface);
-        }
-
-        &::before {
-          transform: scale(1);
         }
       }
 


### PR DESCRIPTION
- Remove ::before pseudo-element and apply background properties directly to button
- Replace transform: scale() with background-size for the same effect
- Apply consistent changes to fill/outline variants of both btn-basic and btn-icon
